### PR TITLE
Set FlushInterval to avoid buffering

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -114,7 +114,8 @@ func newCattleProxies(cattleAddr string) (*httputil.ReverseProxy, *cattleWSProxy
 		req.URL.Host = cattleAddr
 	}
 	cattleProxy := &httputil.ReverseProxy{
-		Director: director,
+		Director:      director,
+		FlushInterval: time.Millisecond * 100,
 	}
 
 	wsProxy := &cattleWSProxy{


### PR DESCRIPTION
If the ReverseProxy's FlushInterval is not set, the io.Copy is used for
sending responses to clients. io.Copy has a 32KB buffer and this
buffering was breaking the python-agent's ability to subscribe to
events via /v1/subscribe. Setting the FlushInterval fixes the problem.
