### PR TITLE
Make it so the default listener is all interfaces.

### DIFF
--- a/proxy/config.go
+++ b/proxy/config.go
@@ -23,7 +23,7 @@ func GetConfig() (*Config, error) {
 	var keyContents string
 	flag.StringVar(&keyFile, "jwt-public-key-file", "", "Location of the public-key used to validate JWTs.")
 	flag.StringVar(&keyContents, "jwt-public-key-contents", "", "An alternative to jwt-public-key-file. The contents of the key.")
-	flag.StringVar(&c.ListenAddr, "listen-address", "localhost:8080", "The tcp address to listen on.")
+	flag.StringVar(&c.ListenAddr, "listen-address", ":8080", "The tcp address to listen on.")
 	flag.StringVar(&c.CattleAddr, "cattle-address", "", "The tcp address to forward cattle API requests to. Will not proxy to cattle api if this option is not provied.")
 	flag.IntVar(&c.ParentPid, "parent-pid", 0, "If provided, this process will exit when the specified parent process stops running.")
 


### PR DESCRIPTION
When starting the proxy in a scratch container, it doesn't necessarily
know its address ahead of time. Set the default to all addrs :8080
instead of localhost:8080.

It looks like cattle is already calling it this way.
(:[CATTLE_PROXY_PORT])

An alternate approach would be to document configuring the
-listen-address variable.
