### PR TITLE
Pull build artifact from Github release

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -1,4 +1,4 @@
 FROM scratch
-ADD ./build/websocket-proxy /websocket-proxy
+ADD ./dist/artifacts/websocket-proxy /websocket-proxy
 
 CMD ["/websocket-proxy"]

--- a/scripts/build-image
+++ b/scripts/build-image
@@ -1,6 +1,18 @@
 #!/bin/bash
 
+set -e
+
 cd $(dirname $0)/..
+mkdir -p dist/artifacts
+
+ARTIFACT_URL=$(curl -s https://api.github.com/repos/rancher/websocket-proxy/releases/latest | jq -r .assets[0].browser_download_url)
+TARGET="dist/artifacts/websocket-proxy.tar.xz"
+
+echo "Downloading ${ARTIFACT_URL}"
+curl -o ${TARGET} -L ${ARTIFACT_URL}
+
+echo "Uncompressing..."
+tar -xJvf ${TARGET} -C dist/artifacts/
 
 TAG=${TAG:=dev}
 IMAGE_NAME=${IMAGE:-"rancher/websocket-proxy"}:${TAG}


### PR DESCRIPTION
Since the build/release process are sometimes decoupled, the Dockerfile.dist now pulls from a Github release artifact.
