### PR TITLE
Remove unneeded client close

### DIFF
--- a/proxy/stats_handler.go
+++ b/proxy/stats_handler.go
@@ -109,11 +109,8 @@ func (h *StatsHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 					doneCounter--
 					countMutex.Unlock()
 				}
-				if errStatus {
-					s.closeClient(h)
-					if doneCounter == 0 {
-						closeConnection(ws)
-					}
+				if errStatus && doneCounter == 0 {
+					closeConnection(ws)
 				}
 			}
 		}(statsInfoStruct)


### PR DESCRIPTION
This was causing a deadlock because stat_handler's read loop blocked
while the closeConnection() call waited on a lock that the multiplexer
held while it tried to write to a blocking channel that the
stat_handler's read loop was resposible for receiving from.
