### PR TITLE
Add X-Forwarded headers to ws requests

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -170,6 +170,7 @@ type cattleWSProxy struct {
 
 func (h *cattleWSProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if strings.EqualFold(req.Header.Get("Upgrade"), "websocket") {
+		proxyprotocol.AddHeaders(req, h.reverseProxy.httpsPorts)
 		h.serveWebsocket(rw, req)
 	} else {
 		h.reverseProxy.ServeHTTP(rw, req)


### PR DESCRIPTION
When in proxy protocol mode, we were not adding the x-forwarded-*
headers for websocket requests

Addresses rancher/rancher#2311
