### PR TITLE
Cleanup erroneous logging

### DIFF
--- a/proxy/frontend_http_handler.go
+++ b/proxy/frontend_http_handler.go
@@ -113,9 +113,11 @@ func (h *FrontendHTTPHandler) shouldHijack(req *http.Request) bool {
 }
 
 func (h *FrontendHTTPHandler) authAndLookup(req *http.Request) (*jwt.Token, string, bool, error) {
-	token, hostKey, ok := h.FrontendHandler.auth(req)
-	if ok {
-		return token, hostKey, ok, nil
+	token, hostKey, authErr := h.FrontendHandler.auth(req)
+	if authErr == nil {
+		return token, hostKey, true, nil
+	} else if !IsNoTokenError(authErr) {
+		log.Infof("Frontend auth failed: %v. Getting new token.", authErr)
 	}
 
 	tokenString, err := h.TokenLookup.Lookup(req)


### PR DESCRIPTION
Requests going to FrontendHTTPHandler would first try to get the token
from the request using FrontendHandler.auth(), but most of these
requests do not even have a token. If that first auth() call fails,
then FrontendHTTPHandler generates its own token. This all works, but
FrontendHandler.auth() logs auth failures, making it look like every
single request that was routed to FrontendHTTPHandler was an auth
failure.
