### PR TITLE
Fix deadlock in FrontendHTTPReader

### DIFF
--- a/proxy/backend_http_reader.go
+++ b/proxy/backend_http_reader.go
@@ -56,7 +56,7 @@ func (b *BackendHTTPReader) start() {
 
 func (b *BackendHTTPReader) Close() error {
 	logrus.Debugf("BACKEND CLOSE REQUESTED %s", b.msgKey)
-	b.backend.closeConnection(b.hostKey, b.msgKey)
+	go b.backend.closeConnection(b.hostKey, b.msgKey)
 	for range b.data {
 		// Make sure the start() go routine is closed
 	}


### PR DESCRIPTION
In the situation in which a client disconnects before all data from
the backend has been sent to the client a deadlock can occur.  In this
situation the data channel is still being written too but there is no
consumer of the channel causing the channel write to block forever.  The
data channel is only purged on Close, but the blocked write to the data
channel will prevent Close from happening.
