### PR TITLE
Don't log stats auth failures

### DIFF
--- a/proxy/stats_handler.go
+++ b/proxy/stats_handler.go
@@ -56,7 +56,6 @@ func (h *StatsHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	statsInfoStructs, authErr := h.auth(req, multiHost)
 	if authErr != nil {
-		log.Infof("Stats auth failed: %v", authErr)
 		http.Error(rw, "Failed authentication", 401)
 		return
 	}


### PR DESCRIPTION
Its just too verbose with the UI is hitting stats with an expired token.