### PR TITLE
Add configurable http timeout for interceptors

### DIFF
--- a/proxy/apiinterceptor/filters/http/generic_http_filter.go
+++ b/proxy/apiinterceptor/filters/http/generic_http_filter.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strconv"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/websocket-proxy/proxy/apiinterceptor/filters"
@@ -53,6 +55,17 @@ func (f *GenericHTTPFilter) ProcessFilter(filter model.FilterData, input model.A
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Length", string(len(bodyContent)))
 
+	var tout int
+	if filter.Timeout == "0" || filter.Timeout == "" {
+		tout = 15
+	} else {
+		var err error
+		tout, err = strconv.Atoi(filter.Timeout)
+		if err != nil {
+			tout = 15
+		}
+	}
+	f.client.Timeout = time.Second * time.Duration(tout)
 	resp, err := f.client.Do(req)
 	if err != nil {
 		return output, err

--- a/proxy/apiinterceptor/interceptor.go
+++ b/proxy/apiinterceptor/interceptor.go
@@ -163,10 +163,15 @@ func (i *interceptor) processPreFilters(path string, otherPathsMatched []string,
 			}
 		} else {
 			//error
-			logrus.Errorf("Error response %v - %v while processing the interceptor %v", responseData.Status, responseData.Body, filterData)
+			logrus.Errorf("Error response %v - %v while processing the interceptor %v for request path %v", responseData.Status, responseData.Message, filterData, api)
+			message := fmt.Sprintf("Error response while processing the interceptor endpoint %v", filterData.Endpoint)
+			if responseData.Message != "" {
+				message = responseData.Message
+			}
+
 			svcErr := model.ProxyError{
 				Status:  strconv.Itoa(responseData.Status),
-				Message: fmt.Sprintf("Error response while processing the endpoint %v", filterData.Endpoint),
+				Message: message,
 			}
 
 			return inputBody, inputHeaders, nil, svcErr

--- a/proxy/apiinterceptor/interceptor.go
+++ b/proxy/apiinterceptor/interceptor.go
@@ -24,12 +24,24 @@ type interceptor struct {
 	apiFilters         map[string]filters.APIFilter
 	pathPreFilters     map[string][]model.FilterData
 	pathDestinations   map[string]http.Handler
+	routes             []*mux.Route
 }
 
 func (i *interceptor) intercept(w http.ResponseWriter, req *http.Request) {
 	path, _ := mux.CurrentRoute(req).GetPathTemplate()
 
-	logrus.Debugf("Request Path matched: %v", path)
+	var otherPathsMatched []string
+	for _, route := range i.routes {
+		var match mux.RouteMatch
+		if route.Match(req, &match) {
+			routePath, err := route.GetPathTemplate()
+			if err == nil && routePath != path && !containsPath(otherPathsMatched, routePath) {
+				otherPathsMatched = append(otherPathsMatched, routePath)
+			}
+		}
+	}
+
+	logrus.Debugf("Request Path matched: %v ,Other Matching paths: %v", path, otherPathsMatched)
 
 	bodyBytes, err := ioutil.ReadAll(req.Body)
 	if err != nil {
@@ -54,11 +66,12 @@ func (i *interceptor) intercept(w http.ResponseWriter, req *http.Request) {
 	}
 
 	api := req.URL.Path
+	method := req.Method
 
-	inputBody, inputHeaders, destination, proxyErr := i.processPreFilters(path, api, jsonInput, headerMap)
+	inputBody, inputHeaders, destination, proxyErr := i.processPreFilters(path, otherPathsMatched, api, method, jsonInput, headerMap)
 	if proxyErr.Status != "" {
 		//error from some filter
-		logrus.Debugf("Error from proxy filter %v", proxyErr)
+		logrus.Debugf("Error processing request interceptor %v", proxyErr)
 		writeError(w, proxyErr)
 		return
 	}
@@ -75,13 +88,13 @@ func (i *interceptor) intercept(w http.ResponseWriter, req *http.Request) {
 	destination.ServeHTTP(w, req)
 }
 
-func (i *interceptor) processPreFilters(path string, api string, body map[string]interface{}, headers map[string][]string) (map[string]interface{}, map[string][]string, http.Handler, model.ProxyError) {
+func (i *interceptor) processPreFilters(path string, otherPathsMatched []string, api string, method string, body map[string]interface{}, headers map[string][]string) (map[string]interface{}, map[string][]string, http.Handler, model.ProxyError) {
 	destinationProxy, ok := i.pathDestinations[path]
 	if !ok {
 		destinationProxy = i.cattleReverseProxy
 	}
 
-	logrus.Debugf("START -- Processing pre filters for request path %v", path)
+	logrus.Debugf("START -- Processing requestInterceptors for request path %v method %v", api, method)
 	inputBody := body
 	inputHeaders := headers
 	//add uuid
@@ -89,8 +102,32 @@ func (i *interceptor) processPreFilters(path string, api string, body map[string
 	//envId
 	envID := extractEnvID(api)
 
-	for _, filterData := range i.pathPreFilters[path] {
-		logrus.Debugf("-- Processing pre filter %v for request path %v --", filterData, path)
+	preFilters := i.pathPreFilters[path]
+
+	for _, pathMatched := range otherPathsMatched {
+		for _, otherFilter := range i.pathPreFilters[pathMatched] {
+			//append if not duplicate
+			if !containsFilter(preFilters, otherFilter) {
+				preFilters = append(preFilters, otherFilter)
+			}
+		}
+	}
+
+	for _, filterData := range preFilters {
+		var methodMatch bool
+		methodMatch = false
+		for _, m := range filterData.Methods {
+			if strings.ToUpper(m) == method {
+				methodMatch = true
+				break
+			}
+		}
+
+		if !methodMatch {
+			continue
+		}
+
+		logrus.Debugf("-- Processing requestInterceptor %v for request path %v --", filterData, api)
 
 		requestData := model.APIRequestData{}
 		requestData.Body = inputBody
@@ -103,16 +140,16 @@ func (i *interceptor) processPreFilters(path string, api string, body map[string
 
 		apiFilter, ok := i.apiFilters[filterData.Type]
 		if !ok {
-			logrus.Errorf("Skipping filter type %v doesn't exist.", filterData.Type)
+			logrus.Errorf("Skipping interceptor type %v doesn't exist.", filterData.Type)
 			continue
 		}
 
 		responseData, err := apiFilter.ProcessFilter(filterData, requestData)
 		if err != nil {
-			logrus.Errorf("Error %v processing the filter %v", err, filterData)
+			logrus.Errorf("Error %v processing the interceptor %v", err, filterData)
 			svcErr := model.ProxyError{
 				Status:  strconv.Itoa(http.StatusInternalServerError),
-				Message: fmt.Sprintf("Error %v processing the filter %v", err, filterData),
+				Message: fmt.Sprintf("Error %v processing the interceptor %v", err, filterData),
 			}
 			return inputBody, inputHeaders, nil, svcErr
 		}
@@ -125,7 +162,7 @@ func (i *interceptor) processPreFilters(path string, api string, body map[string
 			}
 		} else {
 			//error
-			logrus.Errorf("Error response %v - %v while processing the filter %v", responseData.Status, responseData.Body, filterData)
+			logrus.Errorf("Error response %v - %v while processing the interceptor %v", responseData.Status, responseData.Body, filterData)
 			svcErr := model.ProxyError{
 				Status:  strconv.Itoa(responseData.Status),
 				Message: fmt.Sprintf("Error response while processing the endpoint %v", filterData.Endpoint),
@@ -137,7 +174,7 @@ func (i *interceptor) processPreFilters(path string, api string, body map[string
 
 	//send the final body and headers to destination
 
-	logrus.Debugf("DONE -- Processing pre filters for request path %v, following to destination", path)
+	logrus.Debugf("DONE -- Processing requestInterceptors for request path %v", api)
 
 	return inputBody, inputHeaders, destinationProxy, model.ProxyError{}
 }
@@ -203,4 +240,22 @@ func generateUUID() string {
 	time, _ := newUUID.Time()
 	logrus.Debugf("time generated: %v", time)
 	return newUUID.String()
+}
+
+func containsPath(strs []string, newStr string) bool {
+	for _, a := range strs {
+		if a == newStr {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFilter(filters []model.FilterData, newfilter model.FilterData) bool {
+	for _, a := range filters {
+		if a.Type == newfilter.Type && a.Endpoint == newfilter.Endpoint && a.SecretToken == newfilter.SecretToken {
+			return true
+		}
+	}
+	return false
 }

--- a/proxy/apiinterceptor/interceptor.go
+++ b/proxy/apiinterceptor/interceptor.go
@@ -134,6 +134,7 @@ func (i *interceptor) processPreFilters(path string, otherPathsMatched []string,
 		requestData.Headers = inputHeaders
 		requestData.UUID = UUID
 		requestData.APIPath = api
+		requestData.APIMethod = method
 		if envID != "" {
 			requestData.EnvID = envID
 		}

--- a/proxy/apiinterceptor/model/filter_model.go
+++ b/proxy/apiinterceptor/model/filter_model.go
@@ -20,4 +20,5 @@ type APIRequestData struct {
 	APIMethod string                 `json:"APIMethod,omitempty"`
 	EnvID     string                 `json:"envID,omitempty"`
 	Status    int                    `json:"status,omitempty"`
+	Message   string                 `json:"message,omitempty"`
 }

--- a/proxy/apiinterceptor/model/filter_model.go
+++ b/proxy/apiinterceptor/model/filter_model.go
@@ -9,6 +9,7 @@ type FilterData struct {
 	SecretToken string   `json:"secretToken"`
 	Methods     []string `json:"methods"`
 	Paths       []string `json:"paths"`
+	Timeout     string   `json:"timeout"`
 }
 
 //APIRequestData defines the properties of a API Request/Response Body sent to/from a filter

--- a/proxy/apiinterceptor/model/filter_model.go
+++ b/proxy/apiinterceptor/model/filter_model.go
@@ -13,10 +13,11 @@ type FilterData struct {
 
 //APIRequestData defines the properties of a API Request/Response Body sent to/from a filter
 type APIRequestData struct {
-	Headers map[string][]string    `json:"headers,omitempty"`
-	Body    map[string]interface{} `json:"body,omitempty"`
-	UUID    string                 `json:"UUID,omitempty"`
-	APIPath string                 `json:"APIPath,omitempty"`
-	EnvID   string                 `json:"envID,omitempty"`
-	Status  int                    `json:"status,omitempty"`
+	Headers   map[string][]string    `json:"headers,omitempty"`
+	Body      map[string]interface{} `json:"body,omitempty"`
+	UUID      string                 `json:"UUID,omitempty"`
+	APIPath   string                 `json:"APIPath,omitempty"`
+	APIMethod string                 `json:"APIMethod,omitempty"`
+	EnvID     string                 `json:"envID,omitempty"`
+	Status    int                    `json:"status,omitempty"`
 }

--- a/proxy/apiinterceptor/router_constructor.go
+++ b/proxy/apiinterceptor/router_constructor.go
@@ -125,6 +125,12 @@ func buildRouter(configFile string, cattleRevProxy *httputil.ReverseProxy, apiFi
 
 	router.Methods("POST").Path("/v1-api-interceptor/reload").HandlerFunc(http.HandlerFunc(interceptor.reload))
 	router.NotFoundHandler = http.HandlerFunc(interceptor.cattleProxy)
+	var routes []*mux.Route
+	router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		routes = append(routes, route)
+		return nil
+	})
+	interceptor.routes = routes
 	return router, nil
 }
 

--- a/proxy/interceptor_test.go
+++ b/proxy/interceptor_test.go
@@ -162,6 +162,7 @@ func (i *InterceptorTestSuite) TestInterceptor(c *check.C) {
 	c.Assert(actualReq.Body, check.DeepEquals, originalBody)
 	c.Assert(actualReq.UUID, check.Not(check.Equals), "")
 	c.Assert(actualReq.APIPath, check.Equals, "/v1/services")
+	c.Assert(actualReq.APIMethod, check.Equals, "POST")
 }
 
 type mockInterceptor struct {


### PR DESCRIPTION
Changes to add configurable http timeout for interceptors. If no timeout is specified, default timeout used is 15 seconds. After timing out, the API errors out and not processed further.

https://github.com/rancher/rancher/issues/7833