### PR TITLE
return after close ws

### DIFF
--- a/backend/pong_handler.go
+++ b/backend/pong_handler.go
@@ -37,6 +37,7 @@ func (h *pongHandler) startTimer(checkInterval, maxWait int) {
 		if time.Now().After(timeoutAt) {
 			logrus.Warnf("Hit websocket pong timeout. Last websocket ping received at %v. Closing connection.", t)
 			h.ws.Close()
+			return
 		}
 	}
 }


### PR DESCRIPTION
@cjellick Could you review this pr? @ibuildthecloud suggested that the root cause of the rapid growing logs for `Hit websocket pong timeout` is that we didn't return in the current go routine so that ticker will never stop.