### PR TITLE
Allow the token payload to be passed in a websocket message

### DIFF
--- a/proxy/stats_handler.go
+++ b/proxy/stats_handler.go
@@ -54,8 +54,8 @@ func (h *StatsHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		multiHost = true
 	}
 
-	statsInfoStructs, authErr := h.auth(req, multiHost)
-	if authErr != nil {
+	tokenString, authToken, err := h.auth(req)
+	if err != nil {
 		http.Error(rw, "Failed authentication", 401)
 		return
 	}
@@ -66,6 +66,23 @@ func (h *StatsHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ws, err := upgrader.Upgrade(rw, req, nil)
 	if err != nil {
 		http.Error(rw, "Failed to upgrade connection.", 500)
+		return
+	}
+
+	if ok, _ := authToken.Claims["payload"].(bool); ok {
+		ws.SetReadDeadline(time.Now().Add(30 * time.Second))
+		_, content, err := ws.ReadMessage()
+		if err != nil {
+			http.Error(rw, "Failed to read payload", 500)
+			return
+		}
+		tokenString = string(content)
+	}
+
+	statsInfoStructs, err := h.parseStatsInfo(req, tokenString, multiHost)
+	if err != nil {
+		log.Error("Failed to read statsinfo", err)
+		http.Error(rw, "Failed to read payload targets", 500)
 		return
 	}
 
@@ -127,8 +144,21 @@ func (h *StatsHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (h *StatsHandler) auth(req *http.Request, multiHost bool) ([]*statsInfo, error) {
+func (h *StatsHandler) auth(req *http.Request) (string, *jwt.Token, error) {
 	tokenString := req.URL.Query().Get("token")
+	token, err := parseRequestToken(tokenString, h.parsedPublicKey)
+	if err != nil {
+		return "", nil, fmt.Errorf("Error parsing stats token. Failing auth. Error: %v", err)
+	}
+
+	if !token.Valid {
+		return "", nil, fmt.Errorf("Token not valid")
+	}
+
+	return tokenString, token, nil
+}
+
+func (h *StatsHandler) parseStatsInfo(req *http.Request, tokenString string, multiHost bool) ([]*statsInfo, error) {
 	token, err := parseRequestToken(tokenString, h.parsedPublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing stats token. Failing auth. Error: %v", err)
@@ -190,12 +220,8 @@ func getProjectOrService(token *jwt.Token) ([]map[string]string, error) {
 				if ok {
 					projectMap := map[string]string{}
 					for key, value := range projectInterfaceMap {
-						valueString, ok := value.(string)
-						if ok {
-							projectMap[key] = valueString
-						} else {
-							return nil, fmt.Errorf("invalid project/service input data type")
-						}
+						valueString, _ := value.(string)
+						projectMap[key] = valueString
 					}
 					projectList = append(projectList, projectMap)
 				} else {


### PR DESCRIPTION
Tokens can get huge, we now allow reading them from the first message of
the websocket connection.