### PR TITLE
don't close channel if websocket-conn is dropped

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -63,7 +63,9 @@ func connectToProxyWS(ws *websocket.Conn, handlers map[string]Handler) error {
 		_, msg, err := ws.ReadMessage()
 		if err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("Received error reading from socket. Exiting.")
-			close(responseChannel)
+			for _, msgChan := range responders {
+				close(msgChan)
+			}
 			return err
 		}
 


### PR DESCRIPTION
We previously close the channel if the websocket-conn is dropped, but at the same time there
are several go-routines writing to that channel. This will cause panic if we write to a closed channel
So don't close it as it will be garbage collected eventually.