### PR TITLE
Don't set url.Scheme when cleaning path

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -204,7 +204,6 @@ type pathCleaner struct {
 func (p *pathCleaner) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if cleanedPath := p.cleanPath(req.URL.Path); cleanedPath != req.URL.Path {
 		req.URL.Path = cleanedPath
-		req.URL.Scheme = "http"
 	}
 	p.router.ServeHTTP(rw, req)
 }


### PR DESCRIPTION
According to the spec, request.URL represents "is parsed from the URI
supplied on the Request-Line as stored in RequestURI".

Setting the scheme here (and not the host) was causing gorilla/mux
to improperly construct redirect URLs such that they would look
like: `http:///somepath`.