### PR TITLE
Validate the API requests made using Environment keys 

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.8.3
 RUN go get github.com/rancher/trash
 RUN go get github.com/golang/lint/golint
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \

--- a/proxy/apiinterceptor/filters/auth/rancher_token_validate_filter.go
+++ b/proxy/apiinterceptor/filters/auth/rancher_token_validate_filter.go
@@ -214,11 +214,6 @@ func getAccountAndProject(host string, envid string, token string, authHeaders [
 		return "Forbidden", "Forbidden", err
 
 	}
-	if projectid == userid {
-		err := errors.New("Cannot validate project id")
-		return "", "", err
-	}
-
 	log.Debugf("projectid: %v, userid: %v", projectid, userid)
 
 	return projectid, userid, nil


### PR DESCRIPTION
Fix authTokenValidator filter to authorize requests made using Environment keys.

Removing the check that was preventing the validation of env keys, I am not sure what was the purpose of this check originally.

@cjellick  pls. review 